### PR TITLE
Higher zoom levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ var time = ts.getFuzzyLocalTimeFromPoint(timestamp, point);
 //=> '2016-08-25T16:43:12-07:00'
 
 
-// Currently only support zoom level 7
 var tile = [20,49,7];
 var timezone1 = ts.getFuzzyTimezoneFromTile(tile);
 //=> 'America/Los_Angeles'
@@ -25,6 +24,8 @@ var timezone1 = ts.getFuzzyTimezoneFromTile(tile);
 var quadkey = '0230102';
 var timezone2 = ts.getFuzzyTimezoneFromTile(tile);
 //=> 'America/Los_Angeles'
+
+// any tiles passed with zoom levels > 7 will return the timezone of its z7 parent
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var z = 7;
 module.exports = {
   getFuzzyLocalTimeFromPoint: getFuzzyLocalTimeFromPoint,
   getFuzzyTimezoneFromTile: getFuzzyTimezoneFromTile,
-  getFuzzyTimezoneFromQuadkey: getFuzzyTimezoneFromQuadkey
+  getFuzzyTimezoneFromQuadkey: getFuzzyTimezoneFromQuadkey,
+  getz7Parent: getz7Parent
 };
 
 function getFuzzyLocalTimeFromPoint(timestamp, point) {
@@ -18,6 +19,7 @@ function getFuzzyLocalTimeFromPoint(timestamp, point) {
 }
 
 function getFuzzyTimezoneFromTile(tile) {
+  if (tile[2] > 7) tile = getz7Parent(tile);
   var key = tile.join('/');
   if (key in tiles) return tiles[key];
   else throw new Error('tile not found');
@@ -31,4 +33,9 @@ function getFuzzyTimezoneFromQuadkey(quadkey) {
 
   var tile = tilebelt.quadkeyToTile(quadkey);
   return getFuzzyTimezoneFromTile(tile);
+}
+
+function getz7Parent(tile) {
+  if (tile[2] > 7) return getz7Parent(tilebelt.getParent(tile));
+  else return tile;
 }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var z = 7;
 module.exports = {
   getFuzzyLocalTimeFromPoint: getFuzzyLocalTimeFromPoint,
   getFuzzyTimezoneFromTile: getFuzzyTimezoneFromTile,
-  getFuzzyTimezonFromQuadkey: getFuzzyTimezoneFromQuadkey
+  getFuzzyTimezoneFromQuadkey: getFuzzyTimezoneFromQuadkey
 };
 
 function getFuzzyLocalTimeFromPoint(timestamp, point) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "turf-intersect": "^1.4.2"
   },
   "scripts": {
-    "test": "npm run lint; tap -R spec test/test.*.js;",
+    "test": "npm run lint; tap -R spec test/*.test.js;",
     "lint": "eslint *.js --fix",
     "regenerate": "node lib/quantize.js"
   },

--- a/test/test.timespace.js
+++ b/test/test.timespace.js
@@ -6,11 +6,100 @@ test('check zone', function(t) {
   var point = [-122.27783203125, 37.84015683604136];
   t.equal(ts.getFuzzyLocalTimeFromPoint(timestamp, point), '2016-08-25T16:36:59-07:00');
 
-  var tile = [20,49,7];
+  var tile = [20, 49, 7];
   t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
 
   var quadkey = '0230102';
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  t.end();
+});
+
+test('check higher zoom levels', function(t) {
+  var tile, quadkey;
+  // z8
+  tile = [41, 98, 8];
+  quadkey = '02301021';
   t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z9
+  tile = [83, 196, 9];
+  quadkey = '023010211';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z10
+  tile = [167, 392, 10];
+  quadkey = '0230102111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z11
+  tile = [355, 784, 11];
+  quadkey = '02301021111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z12
+  tile = [671, 1568, 12];
+  quadkey = '023010211111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z13
+  tile = [1343, 3136, 13];
+  quadkey = '0230102111111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z14
+  tile = [2687, 6272, 14];
+  quadkey = '02301021111111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z15
+  tile = [5375, 12544, 15];
+  quadkey = '023010211111111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z16
+  tile = [10751, 25088, 16];
+  quadkey = '0230102111111111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z17
+  tile = [21503, 50176, 17];
+  quadkey = '0230102111111111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z18
+  tile = [43007, 100352, 18];
+  quadkey = '02301021111111111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z19
+  tile = [86015, 200704,  19];
+  quadkey = '023010211111111111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z20
+  tile = [172031, 401408, 20];
+  quadkey = '0230102111111111111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
+
+  // z21
+  tile = [344063, 802816, 21];
+  quadkey = '02301021111111111111';
+  t.equal(ts.getFuzzyTimezoneFromTile(tile), 'America/Los_Angeles');
+  t.equal(ts.getFuzzyTimezoneFromQuadkey(quadkey), 'America/Los_Angeles');
 
   t.end();
 });

--- a/test/timespace.test.js
+++ b/test/timespace.test.js
@@ -103,3 +103,12 @@ test('check higher zoom levels', function(t) {
 
   t.end();
 });
+
+test('get z7 parent', function(t) {
+  var expected = [20, 49, 7].join('/');
+  var tile = [344063, 802816, 21];
+  var actual = ts.getz7Parent(tile).join('/');
+  t.equal(actual, expected, 'finds tile\'s z7 parent');
+
+  t.end();
+});


### PR DESCRIPTION
This enhancement would allow timespace to recognize tiles and quadkeys up to the z21 level. 

A naive and imperfect way to implement:
- [x] write tests for `tiles` + `quadkeys` w/ zoom levels > 7
- [x] convert `tiles` at zoom levels > 7 to `quadkey`
- [ ] send that `quadkey` to `getFuzzyTimezoneFromQuadkey`
- [x] adjust `getFuzzyTimezoneFromQuadkey` to ignore anything after the 7th digit
  - this, incorrectly, assumes that every quadkey that is a subset of the z7 tile is fuzzily in the same timezone as its parent quadkey

Alternatively, we could create a more robust `lib/timezones.json` and a function that checks which timezone geometry any quadkey is predominantly located in,  regardless of zoom.
