### PR TITLE
Tilebelt is a dependency, not dev-dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var tiles = require('./lib/timezones.json');
-var tilebelt = require('tilebelt');
+var tilebelt = require('@mapbox/tilebelt');
 var moment = require('moment-timezone');
 var ss = require('simple-statistics');
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "compute fuzzy local time from a location",
   "main": "index.js",
   "dependencies": {
+    "@mapbox/tilebelt": "^1.0.1",
     "d3-queue": "^3.0.3",
     "mkdirp": "^0.5.1",
     "moment": "^2.12.0",
@@ -16,9 +17,7 @@
     "eslint": "^2.5.1",
     "eslint-config-mourner": "^2.0.0",
     "tap": "^5.7.0",
-    "tilebelt": "^1.0.1",
-    "turf": "^2.0.2",
-    "turf-intersect": "^1.4.2"
+    "turf": "^2.0.2"
   },
   "scripts": {
     "test": "npm run lint; tap -R spec test/*.test.js;",

--- a/regenerate/quantize.js
+++ b/regenerate/quantize.js
@@ -8,7 +8,7 @@
 var fs = require('fs');
 var path = require('path');
 var cover = require('tile-cover');
-var tilebelt = require('tilebelt');
+var tilebelt = require('@mapbox/tilebelt');
 var turf = require('turf');
 var d3 = require('d3-queue');
 var mkdirp = require('mkdirp');
@@ -78,7 +78,7 @@ function coverTile(zone, done) {
   } catch (e) {
     console.log('Error detected:', e.message, '; skipping zone');
   }
-  
+
   zonesDone++;
   console.info('Processed', zonesDone + '/' + totalZones)
 

--- a/util/map.js
+++ b/util/map.js
@@ -5,7 +5,7 @@
 
 var path = require('path');
 var cover = require('tile-cover');
-var tilebelt = require('tilebelt');
+var tilebelt = require('@mapbox/tilebelt');
 var turf = require('turf');
 
 var timezones = require('../lib/timezones.json');


### PR DESCRIPTION
@lily-chai This prevents the package to run properly since `tilebelt` is not installed when running `npm install @mapbox/timespace`. This is not discovered by the tests since test environments install the dev-dependencies as well.

I also switched to the namespaced module and removed the unused turf-intersect dev-dependency.

If you approve the PR I can merge and release as a patch.